### PR TITLE
feat: docker-compose.yml (PostgreSQL + Redis + Meilisearch)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# PostgreSQL
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app_dev
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=app_dev
+
+# Redis
+REDIS_URL=redis://:redis@localhost:6379
+REDIS_PASSWORD=redis
+
+# Meilisearch
+MEILISEARCH_URL=http://localhost:7700
+MEILISEARCH_MASTER_KEY=masterkey
+
+# Backend
+PORT=8080
+GIN_MODE=debug
+
+# Frontend
+NEXT_PUBLIC_API_URL=http://localhost:8080
+
+# MCP
+FIGMA_TOKEN=your_figma_token_here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app_dev
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    command: redis-server --requirepass redis
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  meilisearch:
+    image: getmeili/meilisearch:v1
+    ports:
+      - "7700:7700"
+    environment:
+      MEILI_MASTER_KEY: masterkey
+      MEILI_ENV: development
+    volumes:
+      - meilisearch_data:/meili_data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  meilisearch_data:


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with PostgreSQL 16, Redis 7, and Meilisearch services including healthchecks and named volumes
- Add `.env.example` with all environment variables for local development (database, cache, search, backend, frontend, MCP)

closes #11

## Test plan
- [ ] Run `docker compose up -d` and verify all three services start successfully
- [ ] Verify PostgreSQL is accessible on port 5432 with `psql -h localhost -U postgres -d app_dev`
- [ ] Verify Redis is accessible on port 6379 with `redis-cli -a redis ping`
- [ ] Verify Meilisearch is accessible at http://localhost:7700/health
- [ ] Verify healthchecks pass with `docker compose ps`
- [ ] Verify `.env.example` contains all required environment variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)