### PR TITLE
feat: golangci-lint 設定

### DIFF
--- a/backend/.golangci.yml
+++ b/backend/.golangci.yml
@@ -1,0 +1,52 @@
+version: "2"
+linters:
+  enable:
+    - gocritic
+    - misspell
+    - revive
+  settings:
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - style
+        - performance
+    revive:
+      rules:
+        - name: exported
+          severity: warning
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - errcheck
+          - gocritic
+        path: _test\.go
+      - linters:
+          - revive
+        path: cmd/
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/inoue0124/web-agent-dev-template/backend
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/inoue0124/web-agent-dev-template/backend/internal/config"
 	"github.com/inoue0124/web-agent-dev-template/backend/internal/handler"
 	"github.com/inoue0124/web-agent-dev-template/backend/internal/middleware"


### PR DESCRIPTION
## Summary
- Add `backend/.golangci.yml` configuration with linters: errcheck, govet, staticcheck, unused, gosimple, ineffassign, revive, gofmt, goimports, misspell, gocritic
- Configuration uses golangci-lint v2 format (auto-migrated from v1 spec in issue)
- Fix goimports formatting issue in `cmd/server/main.go` (separate local imports from third-party imports)
- Test exclusion rules for `_test.go` files and `cmd/` directory
- gocritic enabled with diagnostic, style, and performance tags

## Test plan
- [x] `golangci-lint run ./...` passes with 0 issues

closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)