### PR TITLE
feat: サンプル CRUD API (Handler → Service → Repository)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -7,8 +7,11 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/inoue0124/web-agent-dev-template/backend/internal/config"
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/database"
 	"github.com/inoue0124/web-agent-dev-template/backend/internal/handler"
 	"github.com/inoue0124/web-agent-dev-template/backend/internal/middleware"
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/repository"
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/service"
 )
 
 func main() {
@@ -22,6 +25,12 @@ func main() {
 		gin.SetMode(gin.ReleaseMode)
 	}
 
+	db, err := database.NewDB(cfg.DatabaseURL)
+	if err != nil {
+		slog.Error("failed to connect to database", "error", err)
+		os.Exit(1)
+	}
+
 	r := gin.New()
 	r.Use(gin.Recovery())
 	r.Use(middleware.Logger())
@@ -29,6 +38,23 @@ func main() {
 
 	healthHandler := handler.NewHealthHandler()
 	r.GET("/health", healthHandler.Health)
+
+	// Item CRUD
+	itemRepo := repository.NewItemRepository(db)
+	itemService := service.NewItemService(itemRepo)
+	itemHandler := handler.NewItemHandler(itemService)
+
+	v1 := r.Group("/api/v1")
+	{
+		items := v1.Group("/items")
+		{
+			items.GET("", itemHandler.List)
+			items.GET("/:id", itemHandler.GetByID)
+			items.POST("", itemHandler.Create)
+			items.PUT("/:id", itemHandler.Update)
+			items.DELETE("/:id", itemHandler.Delete)
+		}
+	}
 
 	slog.Info("server starting", "port", cfg.Port)
 	if err := r.Run(":" + cfg.Port); err != nil {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.12.0
+	github.com/google/uuid v1.6.0
 	gorm.io/driver/postgres v1.6.0
 	gorm.io/gorm v1.31.1
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -32,6 +32,8 @@ github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7Lk
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/backend/internal/handler/item_handler.go
+++ b/backend/internal/handler/item_handler.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/model"
+)
+
+type ItemService interface {
+	List(ctx context.Context) ([]model.Item, error)
+	GetByID(ctx context.Context, id string) (*model.Item, error)
+	Create(ctx context.Context, req model.CreateItemRequest) (*model.Item, error)
+	Update(ctx context.Context, id string, req model.UpdateItemRequest) (*model.Item, error)
+	Delete(ctx context.Context, id string) error
+}
+
+type ItemHandler struct {
+	service ItemService
+}
+
+func NewItemHandler(service ItemService) *ItemHandler {
+	return &ItemHandler{service: service}
+}
+
+func (h *ItemHandler) List(c *gin.Context) {
+	items, err := h.service.List(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch items"})
+		return
+	}
+	c.JSON(http.StatusOK, items)
+}
+
+func (h *ItemHandler) GetByID(c *gin.Context) {
+	item, err := h.service.GetByID(c.Request.Context(), c.Param("id"))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch item"})
+		return
+	}
+	c.JSON(http.StatusOK, item)
+}
+
+func (h *ItemHandler) Create(c *gin.Context) {
+	var req model.CreateItemRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	item, err := h.service.Create(c.Request.Context(), req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create item"})
+		return
+	}
+	c.JSON(http.StatusCreated, item)
+}
+
+func (h *ItemHandler) Update(c *gin.Context) {
+	var req model.UpdateItemRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	item, err := h.service.Update(c.Request.Context(), c.Param("id"), req)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update item"})
+		return
+	}
+	c.JSON(http.StatusOK, item)
+}
+
+func (h *ItemHandler) Delete(c *gin.Context) {
+	if err := h.service.Delete(c.Request.Context(), c.Param("id")); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "item not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete item"})
+		return
+	}
+	c.JSON(http.StatusNoContent, nil)
+}

--- a/backend/internal/handler/item_handler_test.go
+++ b/backend/internal/handler/item_handler_test.go
@@ -1,0 +1,203 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/handler"
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/model"
+)
+
+type mockItemService struct {
+	items []model.Item
+	err   error
+}
+
+func (m *mockItemService) List(_ context.Context) ([]model.Item, error) {
+	return m.items, m.err
+}
+
+func (m *mockItemService) GetByID(_ context.Context, id string) (*model.Item, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	for i := range m.items {
+		if m.items[i].ID.String() == id {
+			return &m.items[i], nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (m *mockItemService) Create(_ context.Context, req model.CreateItemRequest) (*model.Item, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	item := &model.Item{
+		ID:          uuid.New(),
+		Name:        req.Name,
+		Description: req.Description,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+	return item, nil
+}
+
+func (m *mockItemService) Update(_ context.Context, id string, req model.UpdateItemRequest) (*model.Item, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	for i := range m.items {
+		if m.items[i].ID.String() == id {
+			if req.Name != nil {
+				m.items[i].Name = *req.Name
+			}
+			if req.Description != nil {
+				m.items[i].Description = req.Description
+			}
+			return &m.items[i], nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (m *mockItemService) Delete(_ context.Context, id string) error {
+	if m.err != nil {
+		return m.err
+	}
+	for _, item := range m.items {
+		if item.ID.String() == id {
+			return nil
+		}
+	}
+	return gorm.ErrRecordNotFound
+}
+
+func setupRouter(svc handler.ItemService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h := handler.NewItemHandler(svc)
+	g := r.Group("/api/v1/items")
+	{
+		g.GET("", h.List)
+		g.GET("/:id", h.GetByID)
+		g.POST("", h.Create)
+		g.PUT("/:id", h.Update)
+		g.DELETE("/:id", h.Delete)
+	}
+	return r
+}
+
+func TestListItems(t *testing.T) {
+	id := uuid.New()
+	svc := &mockItemService{
+		items: []model.Item{
+			{ID: id, Name: "Test Item", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		},
+	}
+	r := setupRouter(svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/items", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var items []model.Item
+	if err := json.Unmarshal(w.Body.Bytes(), &items); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("expected 1 item, got %d", len(items))
+	}
+}
+
+func TestGetByID(t *testing.T) {
+	id := uuid.New()
+	svc := &mockItemService{
+		items: []model.Item{
+			{ID: id, Name: "Test Item", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		},
+	}
+	r := setupRouter(svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/items/"+id.String(), nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+}
+
+func TestGetByIDNotFound(t *testing.T) {
+	svc := &mockItemService{items: []model.Item{}}
+	r := setupRouter(svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/items/"+uuid.New().String(), nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestCreateItem(t *testing.T) {
+	svc := &mockItemService{}
+	r := setupRouter(svc)
+
+	body, _ := json.Marshal(model.CreateItemRequest{Name: "New Item"})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/items", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected status %d, got %d", http.StatusCreated, w.Code)
+	}
+}
+
+func TestCreateItemBadRequest(t *testing.T) {
+	svc := &mockItemService{}
+	r := setupRouter(svc)
+
+	body := []byte(`{"invalid": true}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodPost, "/api/v1/items", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+}
+
+func TestDeleteItem(t *testing.T) {
+	id := uuid.New()
+	svc := &mockItemService{
+		items: []model.Item{
+			{ID: id, Name: "Test Item"},
+		},
+	}
+	r := setupRouter(svc)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodDelete, "/api/v1/items/"+id.String(), nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected status %d, got %d", http.StatusNoContent, w.Code)
+	}
+}

--- a/backend/internal/model/item.go
+++ b/backend/internal/model/item.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Item struct {
+	ID          uuid.UUID `gorm:"type:uuid;primary_key;default:uuid_generate_v4()" json:"id"`
+	Name        string    `gorm:"type:varchar(255);not null" json:"name"`
+	Description *string   `gorm:"type:text" json:"description"`
+	CreatedAt   time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt   time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+}
+
+func (i *Item) BeforeCreate(tx *gorm.DB) error {
+	if i.ID == uuid.Nil {
+		i.ID = uuid.New()
+	}
+	return nil
+}
+
+type CreateItemRequest struct {
+	Name        string  `json:"name" binding:"required,max=255"`
+	Description *string `json:"description"`
+}
+
+type UpdateItemRequest struct {
+	Name        *string `json:"name" binding:"omitempty,max=255"`
+	Description *string `json:"description"`
+}

--- a/backend/internal/repository/item_repository.go
+++ b/backend/internal/repository/item_repository.go
@@ -1,0 +1,56 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/model"
+)
+
+type ItemRepository struct {
+	db *gorm.DB
+}
+
+func NewItemRepository(db *gorm.DB) *ItemRepository {
+	return &ItemRepository{db: db}
+}
+
+func (r *ItemRepository) List(ctx context.Context) ([]model.Item, error) {
+	var items []model.Item
+	if err := r.db.WithContext(ctx).Order("created_at DESC").Find(&items).Error; err != nil {
+		return nil, fmt.Errorf("failed to list items: %w", err)
+	}
+	return items, nil
+}
+
+func (r *ItemRepository) GetByID(ctx context.Context, id uuid.UUID) (*model.Item, error) {
+	var item model.Item
+	if err := r.db.WithContext(ctx).First(&item, "id = ?", id).Error; err != nil {
+		return nil, fmt.Errorf("failed to get item: %w", err)
+	}
+	return &item, nil
+}
+
+func (r *ItemRepository) Create(ctx context.Context, item *model.Item) error {
+	if err := r.db.WithContext(ctx).Create(item).Error; err != nil {
+		return fmt.Errorf("failed to create item: %w", err)
+	}
+	return nil
+}
+
+func (r *ItemRepository) Update(ctx context.Context, item *model.Item) error {
+	if err := r.db.WithContext(ctx).Save(item).Error; err != nil {
+		return fmt.Errorf("failed to update item: %w", err)
+	}
+	return nil
+}
+
+func (r *ItemRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := r.db.WithContext(ctx).Delete(&model.Item{}, "id = ?", id).Error; err != nil {
+		return fmt.Errorf("failed to delete item: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/service/item_service.go
+++ b/backend/internal/service/item_service.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/model"
+)
+
+type ItemRepository interface {
+	List(ctx context.Context) ([]model.Item, error)
+	GetByID(ctx context.Context, id uuid.UUID) (*model.Item, error)
+	Create(ctx context.Context, item *model.Item) error
+	Update(ctx context.Context, item *model.Item) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+type ItemService struct {
+	repo ItemRepository
+}
+
+func NewItemService(repo ItemRepository) *ItemService {
+	return &ItemService{repo: repo}
+}
+
+func (s *ItemService) List(ctx context.Context) ([]model.Item, error) {
+	return s.repo.List(ctx)
+}
+
+func (s *ItemService) GetByID(ctx context.Context, id string) (*model.Item, error) {
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("invalid item ID: %w", err)
+	}
+	return s.repo.GetByID(ctx, uid)
+}
+
+func (s *ItemService) Create(ctx context.Context, req model.CreateItemRequest) (*model.Item, error) {
+	item := &model.Item{
+		Name:        req.Name,
+		Description: req.Description,
+	}
+	if err := s.repo.Create(ctx, item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+func (s *ItemService) Update(ctx context.Context, id string, req model.UpdateItemRequest) (*model.Item, error) {
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return nil, fmt.Errorf("invalid item ID: %w", err)
+	}
+
+	item, err := s.repo.GetByID(ctx, uid)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Name != nil {
+		item.Name = *req.Name
+	}
+	if req.Description != nil {
+		item.Description = req.Description
+	}
+
+	if err := s.repo.Update(ctx, item); err != nil {
+		return nil, err
+	}
+	return item, nil
+}
+
+func (s *ItemService) Delete(ctx context.Context, id string) error {
+	uid, err := uuid.Parse(id)
+	if err != nil {
+		return fmt.Errorf("invalid item ID: %w", err)
+	}
+	return s.repo.Delete(ctx, uid)
+}

--- a/backend/internal/service/item_service_test.go
+++ b/backend/internal/service/item_service_test.go
@@ -1,0 +1,201 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/model"
+	"github.com/inoue0124/web-agent-dev-template/backend/internal/service"
+)
+
+type mockItemRepo struct {
+	items []model.Item
+	err   error
+}
+
+func (m *mockItemRepo) List(_ context.Context) ([]model.Item, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.items, nil
+}
+
+func (m *mockItemRepo) GetByID(_ context.Context, id uuid.UUID) (*model.Item, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	for i := range m.items {
+		if m.items[i].ID == id {
+			return &m.items[i], nil
+		}
+	}
+	return nil, errors.New("not found")
+}
+
+func (m *mockItemRepo) Create(_ context.Context, item *model.Item) error {
+	if m.err != nil {
+		return m.err
+	}
+	item.ID = uuid.New()
+	item.CreatedAt = time.Now()
+	item.UpdatedAt = time.Now()
+	m.items = append(m.items, *item)
+	return nil
+}
+
+func (m *mockItemRepo) Update(_ context.Context, item *model.Item) error {
+	if m.err != nil {
+		return m.err
+	}
+	for i := range m.items {
+		if m.items[i].ID == item.ID {
+			m.items[i] = *item
+			return nil
+		}
+	}
+	return errors.New("not found")
+}
+
+func (m *mockItemRepo) Delete(_ context.Context, id uuid.UUID) error {
+	if m.err != nil {
+		return m.err
+	}
+	for i := range m.items {
+		if m.items[i].ID == id {
+			m.items = append(m.items[:i], m.items[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("not found")
+}
+
+func TestServiceList(t *testing.T) {
+	repo := &mockItemRepo{
+		items: []model.Item{
+			{ID: uuid.New(), Name: "Item 1"},
+			{ID: uuid.New(), Name: "Item 2"},
+		},
+	}
+	svc := service.NewItemService(repo)
+
+	items, err := svc.List(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestServiceListError(t *testing.T) {
+	repo := &mockItemRepo{err: errors.New("db error")}
+	svc := service.NewItemService(repo)
+
+	_, err := svc.List(context.Background())
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestServiceGetByID(t *testing.T) {
+	id := uuid.New()
+	repo := &mockItemRepo{
+		items: []model.Item{
+			{ID: id, Name: "Test Item"},
+		},
+	}
+	svc := service.NewItemService(repo)
+
+	item, err := svc.GetByID(context.Background(), id.String())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if item.Name != "Test Item" {
+		t.Errorf("expected name 'Test Item', got '%s'", item.Name)
+	}
+}
+
+func TestServiceGetByIDInvalidUUID(t *testing.T) {
+	repo := &mockItemRepo{}
+	svc := service.NewItemService(repo)
+
+	_, err := svc.GetByID(context.Background(), "not-a-uuid")
+	if err == nil {
+		t.Error("expected error for invalid UUID, got nil")
+	}
+}
+
+func TestServiceCreate(t *testing.T) {
+	repo := &mockItemRepo{}
+	svc := service.NewItemService(repo)
+
+	desc := "A description"
+	req := model.CreateItemRequest{
+		Name:        "New Item",
+		Description: &desc,
+	}
+
+	item, err := svc.Create(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if item.Name != "New Item" {
+		t.Errorf("expected name 'New Item', got '%s'", item.Name)
+	}
+	if item.Description == nil || *item.Description != desc {
+		t.Errorf("expected description '%s', got '%v'", desc, item.Description)
+	}
+}
+
+func TestServiceUpdate(t *testing.T) {
+	id := uuid.New()
+	repo := &mockItemRepo{
+		items: []model.Item{
+			{ID: id, Name: "Old Name"},
+		},
+	}
+	svc := service.NewItemService(repo)
+
+	newName := "New Name"
+	req := model.UpdateItemRequest{Name: &newName}
+
+	item, err := svc.Update(context.Background(), id.String(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if item.Name != "New Name" {
+		t.Errorf("expected name 'New Name', got '%s'", item.Name)
+	}
+}
+
+func TestServiceDelete(t *testing.T) {
+	id := uuid.New()
+	repo := &mockItemRepo{
+		items: []model.Item{
+			{ID: id, Name: "To Delete"},
+		},
+	}
+	svc := service.NewItemService(repo)
+
+	err := svc.Delete(context.Background(), id.String())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(repo.items) != 0 {
+		t.Errorf("expected 0 items after delete, got %d", len(repo.items))
+	}
+}
+
+func TestServiceDeleteInvalidUUID(t *testing.T) {
+	repo := &mockItemRepo{}
+	svc := service.NewItemService(repo)
+
+	err := svc.Delete(context.Background(), "not-a-uuid")
+	if err == nil {
+		t.Error("expected error for invalid UUID, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Item` model with UUID primary key, name, and optional description fields
- Implement 3-layer CRUD architecture: `ItemRepository` (GORM) → `ItemService` (business logic with UUID parsing) → `ItemHandler` (Gin HTTP handlers)
- Wire up DI in `main.go` and register routes under `/api/v1/items` (GET, GET/:id, POST, PUT/:id, DELETE/:id)
- Add handler tests (mock service) and service tests (mock repository)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes — handler tests (list, get, get-not-found, create, create-bad-request, delete) and service tests (list, list-error, get, get-invalid-uuid, create, update, delete, delete-invalid-uuid)
- [ ] Manual smoke test: start server with DB, hit `/api/v1/items` endpoints

closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)