### PR TITLE
feat: サンプル Feature Module (一覧 + 詳細 + API 連携)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "sonner": "^2.0.7",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -10459,6 +10460,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/shadcn/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -11878,10 +11889,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/api/items/[id]/route.ts
+++ b/frontend/src/app/api/items/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+const API_BASE = process.env.API_URL || "http://localhost:8080";
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  try {
+    const res = await fetch(`${API_BASE}/api/v1/items/${id}`, { cache: "no-store" });
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json({ error: "Item not found" }, { status: 404 });
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  try {
+    const res = await fetch(`${API_BASE}/api/v1/items/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      return NextResponse.json({ error: "Failed to delete item" }, { status: res.status });
+    }
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json({ error: "Failed to delete item" }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/items/route.ts
+++ b/frontend/src/app/api/items/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+const API_BASE = process.env.API_URL || "http://localhost:8080";
+
+export async function GET() {
+  try {
+    const res = await fetch(`${API_BASE}/api/v1/items`, { cache: "no-store" });
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch {
+    return NextResponse.json([], { status: 200 });
+  }
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const res = await fetch(`${API_BASE}/api/v1/items`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/frontend/src/app/items/[id]/page.tsx
+++ b/frontend/src/app/items/[id]/page.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { getItem } from "@/lib/api/items";
+import { Item } from "@/types/item";
+
+function createMockItem(id: string): Item {
+  return {
+    id,
+    name: `Sample Item (${id})`,
+    description: "This is mock data displayed because the API is unavailable.",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  };
+}
+
+export default async function ItemDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  let item: Item;
+  let isUsingMock = false;
+
+  try {
+    item = await getItem(id);
+  } catch {
+    item = createMockItem(id);
+    isUsingMock = true;
+  }
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Item Detail</h1>
+            <p className="mt-1 text-muted-foreground">View item information</p>
+          </div>
+          <Link href="/items">
+            <Button variant="outline">Back to List</Button>
+          </Link>
+        </div>
+
+        <Separator className="my-6" />
+
+        {isUsingMock && (
+          <div className="mb-4 rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-200">
+            API is unavailable. Showing mock data.
+          </div>
+        )}
+
+        {/* Item Detail Card */}
+        <Card>
+          <CardHeader>
+            <CardTitle>{item.name}</CardTitle>
+            <CardDescription>
+              <span className="font-mono text-xs">{item.id}</span>
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <p className="text-sm font-medium text-muted-foreground">Description</p>
+              {item.description ? (
+                <p className="mt-1">{item.description}</p>
+              ) : (
+                <Badge variant="outline" className="mt-1">
+                  No description
+                </Badge>
+              )}
+            </div>
+            <Separator />
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Created</p>
+                <p className="mt-1 text-sm">
+                  {new Date(item.created_at).toLocaleString("ja-JP")}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Updated</p>
+                <p className="mt-1 text-sm">
+                  {new Date(item.updated_at).toLocaleString("ja-JP")}
+                </p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/items/new/page.tsx
+++ b/frontend/src/app/items/new/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { createItem } from "@/lib/api/items";
+
+const createItemSchema = z.object({
+  name: z.string().min(1, "Name is required").max(100, "Name must be 100 characters or less"),
+  description: z.string().max(500, "Description must be 500 characters or less").optional(),
+});
+
+type FieldErrors = {
+  name?: string;
+  description?: string;
+};
+
+export default function NewItemPage() {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrors({});
+    setSubmitError(null);
+
+    const result = createItemSchema.safeParse({
+      name,
+      description: description || undefined,
+    });
+
+    if (!result.success) {
+      const fieldErrors: FieldErrors = {};
+      for (const issue of result.error.issues) {
+        const field = issue.path[0] as keyof FieldErrors;
+        fieldErrors[field] = issue.message;
+      }
+      setErrors(fieldErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await createItem(result.data);
+      router.push("/items");
+    } catch {
+      setSubmitError("Failed to create item. Please make sure the API server is running.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto max-w-2xl px-6 py-10">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">New Item</h1>
+            <p className="mt-1 text-muted-foreground">Create a new item</p>
+          </div>
+          <Link href="/items">
+            <Button variant="outline">Back to List</Button>
+          </Link>
+        </div>
+
+        <Separator className="my-6" />
+
+        {submitError && (
+          <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200">
+            {submitError}
+          </div>
+        )}
+
+        {/* Form */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Item Details</CardTitle>
+            <CardDescription>Fill in the information below to create a new item.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="name">Name</Label>
+                <Input
+                  id="name"
+                  placeholder="Enter item name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  aria-invalid={!!errors.name}
+                />
+                {errors.name && <p className="text-sm text-destructive">{errors.name}</p>}
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="description">Description (optional)</Label>
+                <Input
+                  id="description"
+                  placeholder="Enter item description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  aria-invalid={!!errors.description}
+                />
+                {errors.description && (
+                  <p className="text-sm text-destructive">{errors.description}</p>
+                )}
+              </div>
+
+              <div className="flex gap-3">
+                <Button type="submit" disabled={isSubmitting}>
+                  {isSubmitting ? "Creating..." : "Create Item"}
+                </Button>
+                <Link href="/items">
+                  <Button type="button" variant="outline">
+                    Cancel
+                  </Button>
+                </Link>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/items/page.tsx
+++ b/frontend/src/app/items/page.tsx
@@ -1,0 +1,139 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getItems } from "@/lib/api/items";
+import { Item } from "@/types/item";
+
+const mockItems: Item[] = [
+  {
+    id: "mock-1",
+    name: "Sample Item 1",
+    description: "This is a sample item for development",
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "mock-2",
+    name: "Sample Item 2",
+    description: "Another sample item",
+    created_at: "2025-01-02T00:00:00Z",
+    updated_at: "2025-01-02T00:00:00Z",
+  },
+  {
+    id: "mock-3",
+    name: "Sample Item 3",
+    description: null,
+    created_at: "2025-01-03T00:00:00Z",
+    updated_at: "2025-01-03T00:00:00Z",
+  },
+];
+
+export default async function ItemsPage() {
+  let items: Item[];
+  let isUsingMock = false;
+
+  try {
+    items = await getItems();
+  } catch {
+    items = mockItems;
+    isUsingMock = true;
+  }
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto max-w-6xl px-6 py-10">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Items</h1>
+            <p className="mt-1 text-muted-foreground">Manage your items</p>
+          </div>
+          <Link href="/items/new">
+            <Button>New Item</Button>
+          </Link>
+        </div>
+
+        <Separator className="my-6" />
+
+        {isUsingMock && (
+          <div className="mb-4 rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-800 dark:bg-yellow-950 dark:text-yellow-200">
+            API is unavailable. Showing mock data.
+          </div>
+        )}
+
+        {/* Items Table */}
+        <Card>
+          <CardHeader>
+            <CardTitle>All Items</CardTitle>
+            <CardDescription>
+              A list of all items. Click on an item to view details.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[200px]">ID</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead className="w-[180px]">Created</TableHead>
+                  <TableHead className="w-[100px] text-right">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-muted-foreground">
+                      No items found.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  items.map((item) => (
+                    <TableRow key={item.id}>
+                      <TableCell className="font-mono text-sm">{item.id}</TableCell>
+                      <TableCell className="font-medium">{item.name}</TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {item.description ? (
+                          item.description
+                        ) : (
+                          <Badge variant="outline">No description</Badge>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {new Date(item.created_at).toLocaleDateString("ja-JP")}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Link href={`/items/${item.id}`}>
+                          <Button variant="ghost" size="sm">
+                            View
+                          </Button>
+                        </Link>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -6,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 import {
   Table,
   TableBody,
@@ -14,8 +16,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
 
 const stats = [
   { title: "Total Items", value: "128", description: "All registered items" },

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { Slot } from "radix-ui"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,11 +1,11 @@
 "use client"
 
-import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
+import * as React from "react"
 
-import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
 
 function Dialog({
   ...props

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import { Label as LabelPrimitive } from "radix-ui"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import * as React from "react"
 import { Separator as SeparatorPrimitive } from "radix-ui"
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 

--- a/frontend/src/lib/api/items.ts
+++ b/frontend/src/lib/api/items.ts
@@ -1,0 +1,30 @@
+import { Item, CreateItemRequest } from "@/types/item";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+
+export async function getItems(): Promise<Item[]> {
+  const res = await fetch(`${API_BASE}/api/v1/items`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Failed to fetch items");
+  return res.json();
+}
+
+export async function getItem(id: string): Promise<Item> {
+  const res = await fetch(`${API_BASE}/api/v1/items/${id}`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Failed to fetch item");
+  return res.json();
+}
+
+export async function createItem(data: CreateItemRequest): Promise<Item> {
+  const res = await fetch(`${API_BASE}/api/v1/items`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error("Failed to create item");
+  return res.json();
+}
+
+export async function deleteItem(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/v1/items/${id}`, { method: "DELETE" });
+  if (!res.ok) throw new Error("Failed to delete item");
+}

--- a/frontend/src/types/item.ts
+++ b/frontend/src/types/item.ts
@@ -1,0 +1,17 @@
+export type Item = {
+  id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CreateItemRequest = {
+  name: string;
+  description?: string;
+};
+
+export type UpdateItemRequest = {
+  name?: string;
+  description?: string;
+};


### PR DESCRIPTION
## Summary
- Add a complete sample CRUD feature module for "items" in the frontend
- Includes list page (Server Component), detail page (Server Component), and new item form (Client Component with Zod validation)
- Add BFF API routes that proxy to the backend API with graceful fallback to mock data when the backend is unavailable
- Fix pre-existing import order lint errors in shadcn/ui components so `npm run build` succeeds

## New Files
- `frontend/src/types/item.ts` — Type definitions (Item, CreateItemRequest, UpdateItemRequest)
- `frontend/src/lib/api/items.ts` — API client for items CRUD operations
- `frontend/src/app/items/page.tsx` — Items list page (Server Component)
- `frontend/src/app/items/[id]/page.tsx` — Item detail page (Server Component)
- `frontend/src/app/items/new/page.tsx` — New item form (Client Component)
- `frontend/src/app/api/items/route.ts` — BFF API Route (GET list, POST create)
- `frontend/src/app/api/items/[id]/route.ts` — BFF API Route (GET detail, DELETE)

## Test plan
- [ ] `cd frontend && npm run build` passes successfully
- [ ] `/items` page renders with mock data when backend is not running
- [ ] `/items/new` page renders the form with Zod validation
- [ ] `/items/[id]` page renders item detail with mock fallback
- [ ] Form validation rejects empty name field
- [ ] When backend API is running, real data is fetched and displayed

closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)